### PR TITLE
add accents to pinyin + make change in settings change the current word display

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,7 +19,7 @@ FROM basic AS dev
 COPY requirements.dev.txt .
 RUN pip install -r requirements.dev.txt && pip freeze > requirements.dev.txt
 
-FROM dev AS buider
+FROM dev AS builder
 
 # hack to optionally copy the fasttext bin file
 # and skip the following download step

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-DOCKER_IMAGE_NAME = danci-explorer
+DOCKER_IMAGE_NAME = explorehsk
 
 # install dependencies
 .PHONY: install-dependencies

--- a/backend/src/init.py
+++ b/backend/src/init.py
@@ -70,8 +70,8 @@ def load_words() -> pd.DataFrame:
 
     df = df[columns]
 
-    df["Pronunciation"] = df["Pronunciation"].apply(add_pinyin_diatrics)
-    
+    df["Pronunciation_with_diatrics"] = df["Pronunciation"].apply(add_pinyin_diatrics)
+
     return df
 
 

--- a/backend/src/init.py
+++ b/backend/src/init.py
@@ -7,7 +7,7 @@ import pandas as pd
 from loguru import logger
 
 from src.config import PATH_TO_FASTTEXT_BIN, PATH_TO_HSK_CSV, PROJECTOR_DATA_DIR
-from src.utils import add_pinyin_diatrics
+from src.utils import add_pinyin_accents
 
 
 def get_ft_model():
@@ -70,7 +70,7 @@ def load_words() -> pd.DataFrame:
 
     df = df[columns]
 
-    df["Pronunciation_with_diatrics"] = df["Pronunciation"].apply(add_pinyin_diatrics)
+    df["Pronunciation_with_accents"] = df["Pronunciation"].apply(add_pinyin_accents)
 
     return df
 

--- a/backend/src/init.py
+++ b/backend/src/init.py
@@ -7,6 +7,7 @@ import pandas as pd
 from loguru import logger
 
 from src.config import PATH_TO_FASTTEXT_BIN, PATH_TO_HSK_CSV, PROJECTOR_DATA_DIR
+from src.utils import add_pinyin_diatrics
 
 
 def get_ft_model():
@@ -68,6 +69,8 @@ def load_words() -> pd.DataFrame:
         columns.append("HSK Level")
 
     df = df[columns]
+
+    df["Pronunciation"] = df["Pronunciation"].apply(add_pinyin_diatrics)
     
     return df
 

--- a/backend/src/utils.py
+++ b/backend/src/utils.py
@@ -12,14 +12,14 @@ PINYIN_V = "u" + "\u0308"
 
 VOWELS = ["a", "e", "i", "o", "u", "v"]
 
-def add_pinyin_diatrics(pinyin: str) -> str:
+def add_pinyin_accents(pinyin: str) -> str:
     """
     Implement rules from http://www.pinyin.info/rules/where.html
 
     Parameters
     ----------
     pinyin : str
-        plain pinyin with no diatrics and numbers at the end of each character, 
+        plain pinyin with no accents and numbers at the end of each character, 
         ie "nv3 peng2 you3", "xing4 fu3"
     """
 

--- a/backend/src/utils.py
+++ b/backend/src/utils.py
@@ -1,0 +1,64 @@
+from loguru import logger
+
+TONE_ACCENTS = {
+    1 : "\u0304",
+    2 : "\u0301",
+    3 : "\u030C",
+    4 : "\u0300",
+    5 : "\u0307",
+}
+
+PINYIN_V = "u" + "\u0308"
+
+VOWELS = ["a", "e", "i", "o", "u", "v"]
+
+def add_pinyin_diatrics(pinyin: str) -> str:
+    """
+    Implement rules from http://www.pinyin.info/rules/where.html
+
+    Parameters
+    ----------
+    pinyin : str
+        plain pinyin with no diatrics and numbers at the end of each character, 
+        ie "nv3 peng2 you3", "xing4 fu3"
+    """
+
+    out_chars = []
+
+    for char in pinyin.split(" "):
+
+        try:
+            tone = int(char[-1])
+        except ValueError as e:
+            logger.warning(e)
+            logger.warning(f"error on character: {char}")
+            logger.warning(f"will return as is")
+            out_chars.append(char)
+            continue
+
+        char = char[:-1]
+        
+        # check for presence of "a" and "e"
+        if ("a" in char) or ("e" in char):
+            char = char.replace("a", "a" + TONE_ACCENTS[tone])
+            char = char.replace("e", "e" + TONE_ACCENTS[tone])
+            char = char.replace("v", PINYIN_V)
+            out_chars.append(char)
+            continue
+        
+        # check for presence of "ou"
+        if "ou" in char:
+            char = char.replace("o", "o" + TONE_ACCENTS[tone])
+            char = char.replace("v", PINYIN_V)
+            out_chars.append(char)
+            continue
+        
+        # check for the last vowel
+        for letter in char[::-1]:
+            if letter in VOWELS:
+                char = char.replace(letter, letter + TONE_ACCENTS[tone])
+                char = char.replace("v", PINYIN_V)
+                out_chars.append(char)
+                break
+    
+    return " ".join(out_chars)

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -271,7 +271,7 @@ main {
     width: 100%;
 }
 
-#use-pinyin-diatrics-checkbox{
+#use-pinyin-accents-checkbox{
     /* Double-sized Checkboxes */
     -ms-transform: scale(2); /* IE */
     -moz-transform: scale(2); /* FF */

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -271,6 +271,14 @@ main {
     width: 100%;
 }
 
+#use-pinyin-diatrics-checkbox{
+    /* Double-sized Checkboxes */
+    -ms-transform: scale(2); /* IE */
+    -moz-transform: scale(2); /* FF */
+    -webkit-transform: scale(2); /* Safari and Chrome */
+    -o-transform: scale(2); /* Opera */
+    transform: translateY(-3px) scale(2);
+}
 
 #about-overlay h2{
     margin-top: 3em;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -133,10 +133,10 @@
                 </div>
                 <div class="setting">
                     <div class="setting-title">
-                        <label class="en" for="use-pinyin-diatrics-checkbox">
-                            Use pīnyīn diatrics
+                        <label class="en" for="use-pinyin-accents-checkbox">
+                            Use pīnyīn accents
                         </label>
-                        <input type="checkbox" id="use-pinyin-diatrics-checkbox" name="use-pinyin-diatrics-checkbox">
+                        <input type="checkbox" id="use-pinyin-accents-checkbox" name="use-pinyin-accents-checkbox">
                         </div>
                     </div>
                 </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -127,10 +127,18 @@
                 <div class="overlay-title">Settings</div>
                 <div class="setting">
                     <div class="setting-title">
-                        <span class="en">HSK Level </span>
-                        <span id="hsk-level-span" class="en"></span>
+                        <label class="en" for="hsk-level-slider">HSK Level <span id="hsk-level-span" class="en"></span></label>
                     </div>
-                    <input type="range" min="1" max="6" value="4" id="hsk-level-slider">
+                    <input type="range" min="1" max="6" value="4" id="hsk-level-slider" name="hsk-level-slider">
+                </div>
+                <div class="setting">
+                    <div class="setting-title">
+                        <label class="en" for="use-pinyin-diatrics-checkbox">
+                            Use pīnyīn diatrics
+                        </label>
+                        <input type="checkbox" id="use-pinyin-diatrics-checkbox" name="use-pinyin-diatrics-checkbox">
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -29,8 +29,16 @@ function renderHskLevel() {
 hskLevelSlider.addEventListener("click", event => {
     event.stopPropagation();
 })
-hskLevelSlider.addEventListener("input", renderHskLevel)
+hskLevelSlider.addEventListener("input", () => {
+    renderHskLevel();
+    refreshWords();
+})
 
+const usePinyinDiatricsCheckbox = document.getElementById('use-pinyin-diatrics-checkbox')
+usePinyinDiatricsCheckbox.addEventListener("click", event => {
+    event.stopPropagation();
+    refreshWords();
+})
 
 // Display suggestions
 
@@ -101,10 +109,24 @@ async function getRandomWord() {
     }
 }
 
+//// Refresh after settings change
+
+function refreshWords() {
+    const centerDiv = document.getElementById("center")
+    const word = centerDiv.querySelector(".center__word").innerText
+    populateFrom(word)
+}
+
 function populateCenter(source) {
     const centerDiv = document.getElementById("center")
     centerDiv.querySelector(".center__word").innerHTML = source["Word"]
-    centerDiv.querySelector(".pinyin").innerText = source["Pronunciation"]
+
+    if (usePinyinDiatricsCheckbox.checked) {
+        centerDiv.querySelector(".pinyin").innerText = source["Pronunciation_with_diatrics"]
+    } else {
+        centerDiv.querySelector(".pinyin").innerText = source["Pronunciation"]
+    }
+
     centerDiv.querySelector(".translation").innerText = source["Definition"]
 }
 
@@ -135,7 +157,11 @@ function populateSuggestions(mostSimilar) {
         const pinyinDiv = document.createElement("div")
         pinyinDiv.classList.add("en") 
         pinyinDiv.classList.add("pinyin")
-        pinyinDiv.innerText = item["Pronunciation"]
+        if (usePinyinDiatricsCheckbox.checked) {
+            pinyinDiv.innerText = item["Pronunciation_with_diatrics"]
+        } else {
+            pinyinDiv.innerText = item["Pronunciation"]
+        }
 
         const translationDiv = document.createElement("div")
         translationDiv.classList.add("en") 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -34,8 +34,8 @@ hskLevelSlider.addEventListener("input", () => {
     refreshWords();
 })
 
-const usePinyinDiatricsCheckbox = document.getElementById('use-pinyin-diatrics-checkbox')
-usePinyinDiatricsCheckbox.addEventListener("click", event => {
+const usePinyinAccentsCheckbox = document.getElementById('use-pinyin-accents-checkbox')
+usePinyinAccentsCheckbox.addEventListener("click", event => {
     event.stopPropagation();
     refreshWords();
 })
@@ -121,8 +121,8 @@ function populateCenter(source) {
     const centerDiv = document.getElementById("center")
     centerDiv.querySelector(".center__word").innerHTML = source["Word"]
 
-    if (usePinyinDiatricsCheckbox.checked) {
-        centerDiv.querySelector(".pinyin").innerText = source["Pronunciation_with_diatrics"]
+    if (usePinyinAccentsCheckbox.checked) {
+        centerDiv.querySelector(".pinyin").innerText = source["Pronunciation_with_accents"]
     } else {
         centerDiv.querySelector(".pinyin").innerText = source["Pronunciation"]
     }
@@ -157,8 +157,8 @@ function populateSuggestions(mostSimilar) {
         const pinyinDiv = document.createElement("div")
         pinyinDiv.classList.add("en") 
         pinyinDiv.classList.add("pinyin")
-        if (usePinyinDiatricsCheckbox.checked) {
-            pinyinDiv.innerText = item["Pronunciation_with_diatrics"]
+        if (usePinyinAccentsCheckbox.checked) {
+            pinyinDiv.innerText = item["Pronunciation_with_accents"]
         } else {
             pinyinDiv.innerText = item["Pronunciation"]
         }


### PR DESCRIPTION
# Before
- Numbers were used to indicate tone, eg. "sheng1 huo2"
- A change in the HSK level setting did not refresh the current word display. You have to change to another word in order to notice the change in HSK level

# After
 - in Settings, option to use accents to indicate tone, eg. "shēng huó"
 - Any change in the settings refresh the current word display