### PR TITLE
Deduplicate entries from the dataset

### DIFF
--- a/backend/src/build_model.py
+++ b/backend/src/build_model.py
@@ -3,6 +3,7 @@ from loguru import logger
 import pickle
 from pathlib import Path
 
+from src.data import dedup_entries
 from src.init import load_words
 from src.model import Model
 
@@ -19,6 +20,7 @@ if __name__ == "__main__":
     output_dir = Path(args.output_dir)
 
     words_df = load_words()
+    words_df = dedup_entries(words_df)
 
     model = Model(words_df)
     output_path = output_dir / "model.pkl"

--- a/backend/src/data.py
+++ b/backend/src/data.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+def dedup_entries(words_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Deduplicate entries in the dataset,
+    based on columns "Word" and "Pronunciation"
+
+    The "HSK Level" is set to the lowest level.
+    The "Definition" is set to be the one of the lowest level.
+
+    Parameters
+    ----------
+    words_df : pd.DataFrame
+        words dataframe, the expected columns are
+        "Word", "Pronunciation", "HSK Level"
+
+    Returns
+    -------
+    pd.DataFrame
+        words dataframe with no duplicates
+    """
+
+    df = words_df.sort_values("HSK Level")
+    df = df.drop_duplicates(["Word", "Pronunciation"], keep="first")
+    
+    ret = words_df.loc[words_df.index.isin(df.index)]
+
+    return ret
+    

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -20,3 +20,21 @@ def occurence_series(words_series) -> pd.Series:
         data=[float(i) for i in range(len(words_series))],
         index=words_series.index
     )
+
+
+@pytest.fixture
+def words_df() -> pd.DataFrame:
+
+    words = ["坚果", "坚持", "坚定", "决定", "肯定", "好", "好", "累", "累"]
+    pronunciations = ["jian1guo3", "jian1chi2", "jian1ding4", "jue2ding4", "ken3ding4", "hao3", "hao3", "lei4", "lei2"]
+    definitions = ["nut", "continue", "stable", "decide", "for sure", "good 1", "good 2", "tired", "accumulate"]
+    hsk_levels = [3, 3, 4, 4, 2, 1, 2, 3, 4]
+
+    return pd.DataFrame(
+        data={
+            "Word" : words, 
+            "Pronunciation" : pronunciations, 
+            "Definition" : definitions,
+            "HSK Level" : hsk_levels
+        },
+    )

--- a/backend/tests/test_data.py
+++ b/backend/tests/test_data.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+from src.data import dedup_entries
+
+
+def test_dedup_entries(words_df: pd.DataFrame):
+    ret = dedup_entries(words_df)
+
+    assert len(ret) == len(words_df) - 1
+    assert len(ret.drop_duplicates(["HSK Level", "Word", "Pronunciation"])) == len(ret)

--- a/backend/tests/test_init.py
+++ b/backend/tests/test_init.py
@@ -5,7 +5,10 @@ def test_load_words():
 
     assert len(df) > 1
     
-    expected_cols = ["HSK Level", "Word", "Pronunciation_with_accents", "Definition", "Id", "Occurence"]
+    expected_cols = ["HSK Level", "Word", "Pronunciation_with_accents", "Definition", "Occurence"]
 
     for col in expected_cols:
         assert col in df.columns
+    
+    assert df.index.name == "Id"
+    


### PR DESCRIPTION
It can happen that the same word, with the same pronunciation and meaning can appear several times in different HSK levels. 

These entries should be deduplicated.

The proposed strategy is to keep the entry with the lowest HSK level.